### PR TITLE
Update pre-commit config and add GHA checks

### DIFF
--- a/.github/pre-commit.yaml
+++ b/.github/pre-commit.yaml
@@ -1,0 +1,17 @@
+name: pre-commit checks
+
+on: [push, pull_request, workflow_dispatch]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+      - uses: pre-commit/action@v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
-  - repo: https://github.com/psf/black
+  - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 23.9.1
     hooks:
       - id: black
@@ -47,6 +47,10 @@ repos:
     hooks:
       - id: end-of-file-fixer
         files: "\\.(py|.txt|.yaml|.json|.in|.md|.toml|.cfg|.html|.yml)$"
+      - id: check-case-conflict
+      - id: check-merge-conflict
+      - id: check-yaml
+      - id: trailing-whitespace
 
   - repo: local
     hooks:


### PR DESCRIPTION
- Use black's pre-commit mirror, which is 2x faster since it uses mypyc-compiled black
- Add additional checks which might come in handy
- Add GH Actions workflow for pre-commit checks (includes unit tests)